### PR TITLE
Remove duplicate tenant debug route

### DIFF
--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -46,12 +46,3 @@ Route::middleware([
 	Route::get('/dashboard', [DashboardController::class, 'index'])
 		->name('dashboard');
 });
-
-Route::middleware(['web', InitializeTenancyByDomain::class, PreventAccessFromCentralDomains::class])
-	->group(function () {
-		Route::get('/debug', function () {
-			dump(DB::connection()->getDatabaseName());
-			return 'Tenant: ' . tenant('id');
-		});
-	});
-


### PR DESCRIPTION
## Summary
- remove duplicate /debug route from tenant route file

## Testing
- `composer test` *(fails: missing vendor/autoload.php)*
- `composer install` *(fails: 403 downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b7011bfb60832cba5cbc8c71c96641