### PR TITLE
chore: consolidate CSS tooling in dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,19 +6,17 @@
         "": {
             "dependencies": {
                 "@tailwindcss/vite": "^4.1.11",
-                "autoprefixer": "^10.4.20",
                 "axios": "^1.7.4",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.0",
-                "tailwindcss": "^4.0.7",
                 "vite": "^7.0.4"
             },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "alpinejs": "^3.4.2",
-                "autoprefixer": "^10.4.2",
+                "autoprefixer": "^10.4.21",
                 "postcss": "^8.4.31",
-                "tailwindcss": "^3.1.0"
+                "tailwindcss": "^3.4.17"
             },
             "optionalDependencies": {
                 "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,9 @@
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.1.11",
-        "autoprefixer": "^10.4.20",
         "axios": "^1.7.4",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0",
-        "tailwindcss": "^4.0.7",
         "vite": "^7.0.4"
     },
     "optionalDependencies": {
@@ -22,8 +20,8 @@
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",
         "alpinejs": "^3.4.2",
-        "autoprefixer": "^10.4.2",
+        "autoprefixer": "^10.4.21",
         "postcss": "^8.4.31",
-        "tailwindcss": "^3.1.0"
+        "tailwindcss": "^3.4.17"
     }
 }


### PR DESCRIPTION
## Summary
- remove Tailwind CSS and autoprefixer from runtime dependencies
- move CSS tooling to devDependencies and align versions to 3.x
- refresh package lock

## Testing
- `npm install`
- `npm run build`
- `php artisan test` *(fails: Failed opening required '/workspace/fieldops360/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b7012025f8832cafc69e346c427702