### PR TITLE
feat: cache tenant user counts

### DIFF
--- a/app/Jobs/UpdateTenantUserCounts.php
+++ b/app/Jobs/UpdateTenantUserCounts.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+
+class UpdateTenantUserCounts implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Recalcula el número de usuarios por tenant y el total global.
+     *
+     * El resultado se almacena en el caché para evitar contar usuarios
+     * en cada solicitud al dashboard central.
+     */
+    public function handle(): void
+    {
+        $total = 0;
+
+        foreach (Tenant::all() as $tenant) {
+            try {
+                tenancy()->initialize($tenant);
+                $count = User::count();
+            } finally {
+                tenancy()->end();
+            }
+
+            Cache::put("tenant:{$tenant->id}:users_count", $count, now()->addMinutes(10));
+            $total += $count;
+        }
+
+        Cache::put('tenants.users.count', $total, now()->addMinutes(10));
+    }
+}

--- a/docs/tenant-user-count-cache.md
+++ b/docs/tenant-user-count-cache.md
@@ -1,0 +1,18 @@
+# Estrategia de cache para el conteo de usuarios por tenant
+
+El dashboard central necesita conocer el número de usuarios existentes en todos los tenants sin ejecutar consultas costosas en cada solicitud. Para ello se utiliza un mecanismo de **caché** junto con un **job asíncrono** que mantiene estos valores actualizados.
+
+## Actualización del cache
+
+El job `UpdateTenantUserCounts` itera por los tenants, cuenta los usuarios de cada base de datos y almacena el resultado en caché:
+
+- `tenant:{id}:users_count` – número de usuarios del tenant individual.
+- `tenants.users.count` – número total de usuarios de todos los tenants.
+
+Las entradas se guardan con una vigencia de 10 minutos (`Cache::put` con `now()->addMinutes(10)`).
+
+## Disparo del job
+
+El controlador `TenantController@index` intenta leer `tenants.users.count`. Si la clave no existe, se despacha el job `UpdateTenantUserCounts` y se muestra provisionalmente el valor `0`.
+
+El job también puede ejecutarse de manera programada (por ejemplo, usando `schedule:run`) o dispararse cuando se creen o eliminen usuarios, garantizando que el dashboard reciba datos lo más actualizados posible sin penalizar el tiempo de respuesta.


### PR DESCRIPTION
## Summary
- cache tenant user totals and update asynchronously
- background job aggregates users per tenant
- document cache refresh strategy

## Testing
- `composer test` *(fails: artisan config:clear missing vendor)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b70121baa4832ca504d7c021831afd