### PR TITLE
Protect central dashboard routes with auth

### DIFF
--- a/app/Http/Controllers/Central/TenantController.php
+++ b/app/Http/Controllers/Central/TenantController.php
@@ -15,10 +15,15 @@ use Illuminate\Support\Facades\Log;
 class TenantController extends Controller
 {
 
-	public function index()
-	{
-		// Métricas globales
-		$tenantsCount = Tenant::count();
+        public function __construct()
+        {
+                $this->middleware(['auth', 'verified']);
+        }
+
+        public function index()
+        {
+                // Métricas globales
+                $tenantsCount = Tenant::count();
 
                 // Intentar obtener el total de usuarios desde caché para evitar
                 // iterar todas las bases de datos de los tenants en cada solicitud

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,9 +20,9 @@ Route::middleware('auth')->group(function () {
 });
 
 foreach (config('tenancy.central_domains') as $domain) {
-	Route::domain($domain)
-	->middleware(['web'/*,'auth' si ya proteges el central*/])
-	->group(function () {
+        Route::domain($domain)
+        ->middleware(['web', 'auth', 'verified'])
+        ->group(function () {
 
 		Route::redirect('/', '/admin');		
 

--- a/tests/Feature/Central/TenantsAccessTest.php
+++ b/tests/Feature/Central/TenantsAccessTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\User;
+
+
+test('guests are redirected to the login page for central dashboard', function () {
+    $response = $this->get(route('central.tenants.dashboard'));
+    $response->assertRedirect(route('login'));
+});
+
+test('authenticated users can visit the central dashboard', function () {
+    $user = User::factory()->create();
+    $user->markEmailAsVerified();
+    $this->actingAs($user);
+
+    $response = $this->get(route('central.tenants.dashboard'));
+    $response->assertStatus(200);
+});
+
+test('guests are redirected to the login page for tenant creation', function () {
+    $response = $this->get(route('central.tenants.create'));
+    $response->assertRedirect(route('login'));
+});
+
+test('authenticated users can visit the tenant creation page', function () {
+    $user = User::factory()->create();
+    $user->markEmailAsVerified();
+    $this->actingAs($user);
+
+    $response = $this->get(route('central.tenants.create'));
+    $response->assertStatus(200);
+});
+


### PR DESCRIPTION
## Summary
- Secure central dashboard and tenant routes with `auth` and `verified` middleware
- Enforce authentication on TenantController
- Add feature tests for central tenant dashboard and create routes

## Testing
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68b716d1769c832c8afc44ae5f9ba9d9