### PR TITLE
Show tenant list on central dashboard

### DIFF
--- a/app/Http/Controllers/Central/TenantController.php
+++ b/app/Http/Controllers/Central/TenantController.php
@@ -36,8 +36,10 @@ class TenantController extends Controller
                         $usersCount = 0;
                 }
 
-		return view('central.tenants.dashboard', compact('tenantsCount', 'usersCount'));
-	}
+                $tenants = Tenant::all();
+
+                return view('central.tenants.dashboard', compact('tenantsCount', 'usersCount', 'tenants'));
+        }
 	public function create()
 	{
 		return view('central.tenants.create');

--- a/resources/views/central/tenants/dashboard.blade.php
+++ b/resources/views/central/tenants/dashboard.blade.php
@@ -23,5 +23,37 @@
             </div>
 
         </div>
+
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 mt-6">
+            <div class="bg-white shadow-sm sm:rounded-lg p-6">
+                <div class="flex justify-between items-center mb-4">
+                    <h3 class="text-lg font-medium text-gray-900">Tenants</h3>
+                    <a href="{{ route('central.tenants.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded">Crear Tenant</a>
+                </div>
+
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nombre</th>
+                            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Estado</th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        @forelse ($tenants as $tenant)
+                            <tr>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $tenant->id }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $tenant->name ?? '-' }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $tenant->status ?? '-' }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">No hay tenants</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- Display all tenants on the central dashboard with ID, name and status
- Link to create new tenants from dashboard

## Testing
- `composer install` *(fails: CONNECT tunnel failed, requires GitHub token)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b71d8e783c832c8255ccb781de887c