### PR TITLE
Add super admin role and middleware for central tenant panel

### DIFF
--- a/app/Http/Middleware/EnsureSuperAdmin.php
+++ b/app/Http/Middleware/EnsureSuperAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureSuperAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user() || ! $request->user()->is_super_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_super_admin',
     ];
 
     /**
@@ -44,6 +45,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_super_admin' => 'boolean',
         ];
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'super-admin' => \App\Http\Middleware\EnsureSuperAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/migrations/2024_09_15_000000_add_is_super_admin_to_users_table.php
+++ b/database/migrations/2024_09_15_000000_add_is_super_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_super_admin')->default(false)->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_super_admin');
+        });
+    }
+};

--- a/database/migrations/tenant/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/tenant/0001_01_01_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->boolean('is_super_admin')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::middleware('auth')->group(function () {
 foreach (config('tenancy.central_domains') as $domain) {
         Route::domain($domain)
 
-        ->middleware(['web', 'auth', 'verified'])
+        ->middleware(['web', 'auth', 'verified', 'super-admin'])
 
         ->group(function () {
 


### PR DESCRIPTION
## Summary
- add `is_super_admin` field and migration for users
- protect central tenant routes with `super-admin` middleware
- allow only super admins through new `EnsureSuperAdmin` middleware

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/fieldops360/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://api.github.com/repos/symfony/polyfill-mbstring/zipball/...: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b72053d7d8832ca7faa18ca4775a1e